### PR TITLE
Lunch survey - GCP Developer experience improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,31 +39,43 @@ popular No-Code Form Builders such as [SurveyMonkey](https://www.surveymonkey.co
 * Gradle 
 
 ## Deployment and Hosting
+
+### Intended Audience and Prerequisites ###
+This section of the guide is written for a developer interested in cloning this repository to modify it or deploy it as-is to their own environment.
+As such basic knowledge of MongoDB Cloud Atlas (setting up an account) and creating the required database to connect to is something that can be done. If you are interested, in additional steps on how to set this up I'm happy to provide them.
+
 Any cloud provider can be used (AWS, Azure, Heroku, GCP).  
 
-For it's ease of use and ability to scale from 0 to n instances as-needed on demand I chose [Google Cloud Platform App Engine](https://cloud.google.com/appengine/docs).  
+For its ease of use and ability to scale from 0 to n instances as needed on demand I chose [Google Cloud Platform App Engine](https://cloud.google.com/appengine/docs).  
 
-### GCP App Engine Deployment
+### GCP App Engine Local Build + Deployment
 
-The following steps can be run from a local development environment shell.
+The following steps can be run from a Unix-based Terminal.  I'm using `bash` as my shell in the samples below.  
 
-1. Create a GCP cloud account + download and install the gcloud command-line tool.
-2. Set the APP_MONGODB_CONN environment variable to the value consistent with your MONGODB Cloud Atlas cluster
-3. Change directories to the top-level directory of the poll project `cd $projectDir` 
-3. Use the Gradle wrapper to run the bootJar task `./gradlew bootJar` > **Note** > Boot jar will be assembled and generated to $projectDir/build/libs
-4. Use the Gradle wrapper to run the custom generateAppYaml task `./gradlew generateAppYaml` (An updated app.yaml that contains the value of `APP_MONGODB_CONN` will be generated to `$projectDir/build/libs)`
-5. `cd $projectDir/build/libs`
-6. Run `gcloud app deploy ./poll-0.0.3.SNAPSHOT.jar --appyaml=./app.yaml`
+Following these steps, keeps development costs down, as we essentially assemble the binary artifacts GCP requires for execution in an APP ENGINE environment ahead of time (on a local development or build server). It also allows the application to be spun up only when users clicked a link shared with them via email.
 
-If deployment succeeds, GCP App Engine will share the URL of your deployed application with you in the console
 
-This kept costs down and allowed the application to be spun up only when users clicked a link shared with them via email.
+1. Create a GCP cloud account
+2. Follow [Google's online guide](https://cloud.google.com/sdk/docs/install) to download + install the `gcloud` CLI <br>
+   ℹ️ **Note:** Make sure you have the recommended version of Python installed locally as outlined in the docs
+3. Use git to clone this repositories main branch
+4. Change directories to the top-level directory of the poll project `cd $projectDir`
+5. Set the APP_MONGODB_CONN environment variable to the value consistent with your MONGODB Cloud Atlas cluster
+6. Use the Gradle wrapper to run the bootJar task `./gradlew bootJar` <br>
+   ℹ️ **Note:** An executable jar file will be assembled and generated to `$projectDir/build/libs`
+7. Use the Gradle wrapper to run the custom generateAppYaml task `./gradlew generateAppYaml` <br>
+   ℹ️ **Note:** An updated `app.yaml` that contains the value of `APP_MONGODB_CONN` will be generated to `$projectDir/build/libs`
+8. `cd $projectDir/build/libs`
+9. Run `gcloud app deploy ./poll-0.0.3.SNAPSHOT.jar --appyaml=./app.yaml` <br>
+   ℹ️ **Note:** If deployment succeeds, GCP App Engine will share the URL of your running application with you in the console
+
 
 ## Limitations
-1. At this time, it is a heavy lift to design, add or display alternate questions. A configurable question provider would be a great feature to have.
+1. At this time, it is a heavy lift to design, add or display alternate questions. To make this single-question poll survey reusable in other contexts, a configurable question provider would be a great feature to have. <br>
+ℹ️ **Note:** See [GitHub issue #2](https://github.com/afarentino/poll/issues/2) for further details.
 
 
-2. Deployment instructions (for additional cloud platform) and automated steps to provision any required infrastructure (including the MongoDB Atlas database) would also be a nice-to-have. 
+2. Deployment instructions (for additional cloud platforms) and automated steps to provision any required infrastructure (including the MongoDB Atlas database) would also be a nice-to-have. 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,27 @@ Any cloud provider can be used (AWS, Azure, Heroku, GCP).
 
 For it's ease of use and ability to scale from 0 to n instances as-needed on demand I chose [Google Cloud Platform App Engine](https://cloud.google.com/appengine/docs).  
 
+### GCP App Engine Deployment
+
+The following steps can be run from a local development environment shell.
+
+1. Create a GCP cloud account + download and install the gcloud command-line tool.
+2. Set the APP_MONGODB_CONN environment variable to the value consistent with your MONGODB Cloud Atlas cluster
+3. Change directories to the top-level directory of the poll project `cd $projectDir` 
+3. Use the Gradle wrapper to run the bootJar task `./gradlew bootJar` > **Note** > Boot jar will be assembled and generated to $projectDir/build/libs
+4. Use the Gradle wrapper to run the custom generateAppYaml task `./gradlew generateAppYaml` (An updated app.yaml that contains the value of `APP_MONGODB_CONN` will be generated to `$projectDir/build/libs)`
+5. `cd $projectDir/build/libs`
+6. Run `gcloud app deploy ./poll-0.0.3.SNAPSHOT.jar --appyaml=./app.yaml`
+
+If deployment succeeds, GCP App Engine will share the URL of your deployed application with you in the console
+
 This kept costs down and allowed the application to be spun up only when users clicked a link shared with them via email.
 
 ## Limitations
 1. At this time, it is a heavy lift to design, add or display alternate questions. A configurable question provider would be a great feature to have.
 
 
-2. Deployment instructions (for each cloud platform) and automated steps to provision any required infrastructure (including the MongoDB Atlas database) would also be a nice-to-have. 
+2. Deployment instructions (for additional cloud platform) and automated steps to provision any required infrastructure (including the MongoDB Atlas database) would also be a nice-to-have. 
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.0.3'
@@ -27,3 +29,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+// Apply custom build tasks
+apply from: "$projectDir/gradle/custom.gradle"
+

--- a/gradle/custom.gradle
+++ b/gradle/custom.gradle
@@ -1,0 +1,53 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.yaml:snakeyaml:2.0'
+    }
+}
+
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.DumperOptions
+import java.nio.file.Files
+import java.nio.file.Paths
+
+// Utility method that updates a yaml value based on the current value of a
+// System environment variable
+Object updateYamlValue(String fileName, String envVar, File destDir) {
+    File temp = new File(fileName)
+
+    def destFile = destDir.getAbsolutePath() + System.getProperty("file.separator") + temp.getName()
+    def updatedValue = System.getenv(envVar)
+    if (updatedValue == null) {
+        throw new GradleException("Environment variable $envVar is not set.")
+    }
+
+    // Read the YAML file
+    def dump = new DumperOptions()
+    dump.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+    dump.setPrettyFlow(true);
+    dump.setIndent(2);
+    dump.setCanonical(false);
+    dump.setExplicitStart(false);
+
+    def yaml = new Yaml(dump)
+    def data = (Map) yaml.load(Files.newInputStream(Paths.get(fileName)))
+
+    // Update the env_variables section
+    data['env_variables']."${envVar}" = updatedValue
+
+    // Write the updated YAML file
+    Files.write(Paths.get(destFile), yaml.dump(data).getBytes())
+    System.out.println("YAML file generated is: " + destFile)
+}
+
+tasks.register("generateAppYaml") {
+    group = "build"
+    description = "Generates the final GCP App Engine file to use during cloud deployment"
+    doLast {
+        def destDir = file("$buildDir/libs")
+        updateYamlValue("$projectDir/src/main/appengine/app.yaml", "APP_MONGODB_CONN", destDir)
+        System.out.print("APP_MONGODB_CONN updated")
+    }
+}

--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,3 +1,5 @@
 runtime: java17
 automatic_scaling:
   max_instances: 1
+env_variables:
+  APP_MONGODB_CONN: "Your value"


### PR DESCRIPTION
In this PR we add a Gradle task that is responsible for reading the value of the environment variable APP_MONGODB_CONN and outputting it to the app.yaml GCP file.  This generated file along with the executable jar file can that be used to directly deploy and run against the Google App Engine GCP Java 17 environment.

README updated with steps to use the task as well.