### PR TITLE
WIP: Changes to integrate role-based authorization using Keycloak 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.github.afarentino'
-version = '0.0.3-SNAPSHOT'
+version = '0.0.4-SNAPSHOT'
 sourceCompatibility = '17'
 
 repositories {
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.apache.commons:commons-csv:1.10.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/github/afarentino/poll/FormController.java
+++ b/src/main/java/com/github/afarentino/poll/FormController.java
@@ -37,11 +37,11 @@ public class FormController {
 
         model.addAttribute("user", answers.getFirstName());
         model.addAttribute("questions", answers);
-        // TODO: Add this feature flag to layout
-        // model.addAttribute("admin", "true");
+        model.addAttribute("admin", "true");
         return "thanks";
     }
 
+    // If user hits this endpoint they will need to login.
     @GetMapping(value= "/survey/results")
     @ResponseBody
     public ResponseEntity<Resource> csvDownload() throws IOException {

--- a/src/main/java/com/github/afarentino/poll/SecurityConfig.java
+++ b/src/main/java/com/github/afarentino/poll/SecurityConfig.java
@@ -1,0 +1,20 @@
+package com.github.afarentino.poll;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain configure(final HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests().requestMatchers("/", "/survey", "/css/**", "/js/**", "/images/**", "/scripts/**").permitAll()
+                        .anyRequest().authenticated().and().oauth2Login();
+        return http.build();
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,14 @@ spring.data.mongodb.database=answers
 
 # Set the port to the PORT environment variable
 server.port=${PORT:8080}
+
+# Keycloak login
+spring.security.oauth2.client.provider.keycloak.issuer-uri=http://localhost:8180/realms/poll
+spring.security.oauth2.client.registration.keycloak.client-id=poll
+spring.security.oauth2.client.registration.keycloak.client-secret=${KEYCLOAK_CLIENT_SECRET:undefined}
+spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.keycloak.redirect-uri=http://localhost:${server.port}/login/oauth2/code/keycloak
+spring.security.oauth2.client.registration.keycloak.scope=openid,profile,roles
+
+logging.level.org.springframework.security=TRACE
+


### PR DESCRIPTION
When merged this PR fixes #6.  

At the moment this feature branch has code on it that forces users who access protected endpoints in the application to be redirected to a Keycloak OAuth2 login page.  If the provided user is in the system, they are granted access to the /survey/results endpoint.

Prior to merging to the main branch, the following additional changes need to be made:
1. Configure role-based authorization for the endpoint.  If a user is authenticated they also need to have the ROLE_OWNER assigned before gaining access to the endpoint
2. Build and deploy a custom Keycloak distribution that has client-bound traffic secured over https. It should also run on a public cloud while easily auto-scaling to 0 instances when not in use.
3. Setup logout handlers in Spring Boot application and add unit tests for additional functionality

References:
* https://technospace.medium.com/secure-spring-boot-application-with-openid-connect-and-role-based-authorization-efaeceb014c7
* [Dzone Working with KeyCloak in Spring Boot 3 apps](https://dzone.com/articles/spring-oauth2-resource-servers)